### PR TITLE
Add guest inquiry workflow

### DIFF
--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -12,6 +12,19 @@ exports.authenticateToken = (req, res, next) => {
   });
 };
 
+// Optional authentication middleware - proceeds without user if no or invalid token
+exports.optionalAuthenticate = (req, res, next) => {
+  const token = req.headers['authorization']?.split(' ')[1];
+  if (!token) return next();
+
+  jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
+    if (!err) {
+      req.user = decoded;
+    }
+    next();
+  });
+};
+
 // Role-based authorization middleware
 exports.requireRole = (allowedRoles) => {
   return (req, res, next) => {

--- a/backend/models/PaymentInquiry.js
+++ b/backend/models/PaymentInquiry.js
@@ -1,7 +1,11 @@
 const mongoose = require('mongoose');
 
 const paymentInquirySchema = new mongoose.Schema({
-  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  firstName: String,
+  lastName: String,
+  phoneNumber: String,
+  message: String,
   courseId: { type: mongoose.Schema.Types.ObjectId, ref: 'Course', required: true },
   status: {
     type: String,

--- a/backend/routes/paymentInquiryRoutes.js
+++ b/backend/routes/paymentInquiryRoutes.js
@@ -1,9 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/paymentInquiryController');
-const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+const {
+  authenticateToken,
+  optionalAuthenticate,
+  requireAdmin
+} = require('../middleware/authMiddleware');
 
-router.post('/', authenticateToken, controller.createInquiry);
+router.post('/', optionalAuthenticate, controller.createInquiry);
 router.get('/my', authenticateToken, controller.getMyInquiries);
 router.get('/', authenticateToken, requireAdmin, controller.getInquiries);
 router.put('/:id/approve', authenticateToken, requireAdmin, controller.approveInquiry);

--- a/frontend/src/pages/Admin/InquiryList.jsx
+++ b/frontend/src/pages/Admin/InquiryList.jsx
@@ -30,7 +30,7 @@ function InquiryList() {
         {inquiries.map(i => (
           <li key={i._id} className="list-group-item d-flex justify-content-between align-items-center">
             <span>
-              {i.userId?.firstName} {i.userId?.lastName} - {i.courseId?.title}
+              {i.userId?.firstName || i.firstName} {i.userId?.lastName || i.lastName} - {i.phoneNumber} - {i.courseId?.title}
             </span>
             {i.status === 'approved' ? (
               <span className="badge bg-success">Approved</span>


### PR DESCRIPTION
## Summary
- allow payment inquiries without logging in
- store guest contact info on inquiries
- create a user automatically when an inquiry is approved
- display phone/name in admin inquiry list
- add pop-up inquiry form in class detail page

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm install --prefix backend` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68773353102483228367a82f9c434f91