### PR TITLE
Add admin inquiry detail page

### DIFF
--- a/backend/controllers/paymentInquiryController.js
+++ b/backend/controllers/paymentInquiryController.js
@@ -94,6 +94,23 @@ exports.getInquiries = async (req, res) => {
   }
 };
 
+// Get single inquiry (Admin only)
+exports.getInquiry = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const inquiry = await PaymentInquiry.findById(id)
+      .populate('userId', 'firstName lastName phoneNumber')
+      .populate('courseId', 'title price');
+    if (!inquiry) {
+      return res.status(404).json({ message: 'Inquiry not found' });
+    }
+    res.json({ inquiry });
+  } catch (err) {
+    console.error('Get inquiry error:', err);
+    res.status(500).json({ message: 'Failed to fetch inquiry' });
+  }
+};
+
 exports.approveInquiry = async (req, res) => {
   try {
     const { id } = req.params;

--- a/backend/routes/paymentInquiryRoutes.js
+++ b/backend/routes/paymentInquiryRoutes.js
@@ -10,6 +10,7 @@ const {
 router.post('/', optionalAuthenticate, controller.createInquiry);
 router.get('/my', authenticateToken, controller.getMyInquiries);
 router.get('/', authenticateToken, requireAdmin, controller.getInquiries);
+router.get('/:id', authenticateToken, requireAdmin, controller.getInquiry);
 router.put('/:id/approve', authenticateToken, requireAdmin, controller.approveInquiry);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -59,6 +59,7 @@ import BankPaymentRequests from './pages/Admin/BankPaymentRequests';
 import LibraryList from './pages/Admin/LibraryList';
 import UploadLibrary from './pages/Admin/UploadLibrary';
 import InquiryList from './pages/Admin/InquiryList';
+import InquiryDetail from './pages/Admin/InquiryDetail';
 import TeacherListAdmin from './pages/Admin/TeacherList';
 import CreateTeacher from './pages/Admin/CreateTeacher';
 import EditTeacher from './pages/Admin/EditTeacher';
@@ -144,6 +145,7 @@ function App() {
         <Route path="/admin/payments" element={<RequireAdmin><PaymentList /></RequireAdmin>} />
         <Route path="/admin/bank-payments" element={<RequireAdmin><BankPaymentRequests /></RequireAdmin>} />
         <Route path="/admin/inquiries" element={<RequireAdmin><InquiryList /></RequireAdmin>} />
+        <Route path="/admin/inquiries/:inquiryId" element={<RequireAdmin><InquiryDetail /></RequireAdmin>} />
         <Route path="/admin/library" element={<RequireAdmin><LibraryList /></RequireAdmin>} />
         <Route path="/admin/library/upload" element={<RequireAdmin><UploadLibrary /></RequireAdmin>} />
         <Route path="/admin/teachers" element={<RequireAdmin><TeacherListAdmin /></RequireAdmin>} />

--- a/frontend/src/pages/Admin/InquiryDetail.jsx
+++ b/frontend/src/pages/Admin/InquiryDetail.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import api from '../../api';
+
+function InquiryDetail() {
+  const { inquiryId } = useParams();
+  const navigate = useNavigate();
+  const [inquiry, setInquiry] = useState(null);
+
+  const load = () => {
+    api.get(`/inquiries/${inquiryId}`)
+      .then(res => setInquiry(res.data.inquiry))
+      .catch(() => navigate('/admin/inquiries'));
+  };
+
+  useEffect(() => {
+    load();
+  }, [inquiryId]);
+
+  const approve = async () => {
+    try {
+      await api.put(`/inquiries/${inquiryId}/approve`);
+      load();
+    } catch {
+      alert('Failed to approve');
+    }
+  };
+
+  if (!inquiry) return null;
+
+  return (
+    <div className="container mt-4">
+      <h2>Inquiry Details</h2>
+      <ul className="list-group mb-3">
+        <li className="list-group-item"><strong>Name:</strong> {inquiry.userId?.firstName || inquiry.firstName} {inquiry.userId?.lastName || inquiry.lastName}</li>
+        <li className="list-group-item"><strong>Phone:</strong> {inquiry.phoneNumber}</li>
+        <li className="list-group-item"><strong>Course:</strong> {inquiry.courseId?.title}</li>
+        <li className="list-group-item"><strong>Status:</strong> {inquiry.status}</li>
+        {inquiry.message && <li className="list-group-item"><strong>Message:</strong> {inquiry.message}</li>}
+      </ul>
+      {inquiry.status !== 'approved' && (
+        <button className="btn btn-primary" onClick={approve}>Approve</button>
+      )}
+    </div>
+  );
+}
+
+export default InquiryDetail;
+

--- a/frontend/src/pages/Admin/InquiryList.jsx
+++ b/frontend/src/pages/Admin/InquiryList.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import api from '../../api';
 
 function InquiryList() {
@@ -32,11 +33,14 @@ function InquiryList() {
             <span>
               {i.userId?.firstName || i.firstName} {i.userId?.lastName || i.lastName} - {i.phoneNumber} - {i.courseId?.title}
             </span>
-            {i.status === 'approved' ? (
-              <span className="badge bg-success">Approved</span>
-            ) : (
-              <button className="btn btn-sm btn-primary" onClick={() => approve(i._id)}>Approve</button>
-            )}
+            <div className="d-flex gap-2 align-items-center">
+              <Link className="btn btn-sm btn-outline-secondary" to={`/admin/inquiries/${i._id}`}>View</Link>
+              {i.status === 'approved' ? (
+                <span className="badge bg-success">Approved</span>
+              ) : (
+                <button className="btn btn-sm btn-primary" onClick={() => approve(i._id)}>Approve</button>
+              )}
+            </div>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- support fetching a single inquiry
- expose `/inquiries/:id` route
- add admin page to view an inquiry
- link to the new page from the inquiry list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68773831350883229e3eb731170ba512