### PR TITLE
Add phone-based password reset

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,8 @@ import Navbar from './components/Navbar';
 import Home from './pages/Home';
 import Login from './pages/Auth/Login';
 import Register from './pages/Auth/Register';
+import ForgotPassword from './pages/Auth/ForgotPassword';
+import ResetPassword from './pages/Auth/ResetPassword';
 
 // Class Navigation
 import GradeList from './pages/Classes/GradeList';
@@ -83,6 +85,8 @@ function App() {
         {/* Auth */}
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
 
         {/* Home */}
         <Route path="/" element={<Home />} />

--- a/frontend/src/pages/Auth/ForgotPassword.jsx
+++ b/frontend/src/pages/Auth/ForgotPassword.jsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../../api';
+
+const ForgotPassword = () => {
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [otp, setOtp] = useState('');
+  const [step, setStep] = useState('request');
+  const [msg, setMsg] = useState('');
+  const navigate = useNavigate();
+
+  const sendOtp = async (e) => {
+    e.preventDefault();
+    setMsg('');
+    try {
+      await api.post('/auth/forgot-password', { phoneNumber });
+      setStep('verify');
+      setMsg('OTP sent. Please check your phone.');
+    } catch (err) {
+      setMsg(err.response?.data?.message || 'Failed to send OTP.');
+    }
+  };
+
+  const verifyOtp = async (e) => {
+    e.preventDefault();
+    setMsg('');
+    try {
+      await api.post('/auth/verify-otp', { phoneNumber, otp });
+      navigate('/reset-password', { state: { phoneNumber } });
+    } catch (err) {
+      setMsg(err.response?.data?.message || 'Failed to verify OTP.');
+    }
+  };
+
+  return (
+    <div className="container py-5">
+      <h3>Forgot Password</h3>
+      {step === 'request' ? (
+        <form onSubmit={sendOtp}>
+          <input
+            className="form-control mb-2"
+            placeholder="Phone Number"
+            value={phoneNumber}
+            onChange={(e) => setPhoneNumber(e.target.value)}
+          />
+          <button className="btn btn-primary">Send OTP</button>
+          {msg && <div className="alert alert-info mt-3">{msg}</div>}
+        </form>
+      ) : (
+        <form onSubmit={verifyOtp}>
+          <input
+            className="form-control mb-2"
+            placeholder="Enter OTP"
+            value={otp}
+            onChange={(e) => setOtp(e.target.value)}
+          />
+          <button className="btn btn-primary">Verify OTP</button>
+          {msg && <div className="alert alert-info mt-3">{msg}</div>}
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import api from '../../api';
 
 const Login = () => {
@@ -35,6 +35,9 @@ const Login = () => {
         <input className="form-control mb-2" placeholder="Phone Number" value={phoneNumber} onChange={(e) => setPhoneNumber(e.target.value)} />
         <input className="form-control mb-2" type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
         <button className="btn btn-primary">Login</button>
+        <div className="mt-2">
+          <Link to="/forgot-password">Forgot Password?</Link>
+        </div>
         {msg && <div className="alert alert-info mt-3">{msg}</div>}
       </form>
     </div>

--- a/frontend/src/pages/Auth/ResetPassword.jsx
+++ b/frontend/src/pages/Auth/ResetPassword.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import api from '../../api';
+
+const ResetPassword = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const phoneNumber = location.state?.phoneNumber || '';
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmNewPassword, setConfirmNewPassword] = useState('');
+  const [msg, setMsg] = useState('');
+
+  const handleReset = async (e) => {
+    e.preventDefault();
+    setMsg('');
+    try {
+      await api.post('/auth/reset-password', {
+        phoneNumber,
+        newPassword,
+        confirmNewPassword,
+      });
+      setMsg('Password reset successfully. You can now login.');
+      setTimeout(() => navigate('/login'), 1000);
+    } catch (err) {
+      setMsg(err.response?.data?.message || 'Failed to reset password.');
+    }
+  };
+
+  return (
+    <div className="container py-5">
+      <h3>Reset Password</h3>
+      <form onSubmit={handleReset}>
+        <input
+          className="form-control mb-2"
+          type="password"
+          placeholder="New Password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+        />
+        <input
+          className="form-control mb-2"
+          type="password"
+          placeholder="Confirm New Password"
+          value={confirmNewPassword}
+          onChange={(e) => setConfirmNewPassword(e.target.value)}
+        />
+        <button className="btn btn-success">Reset</button>
+        {msg && <div className="alert alert-info mt-3">{msg}</div>}
+      </form>
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
## Summary
- allow users to access forgot-password flow from login page
- implement ForgotPassword and ResetPassword pages
- add routes for password recovery

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68773e71c4988322ad0227e699979cbc