### PR TITLE
Add e-library categories and editing

### DIFF
--- a/backend/controllers/libraryController.js
+++ b/backend/controllers/libraryController.js
@@ -2,7 +2,7 @@ const LibraryItem = require('../models/LibraryItem');
 
 exports.createItem = async (req, res) => {
   try {
-    const { title, description } = req.body;
+    const { title, description, category, grade, subject } = req.body;
     if (!req.file) return res.status(400).json({ message: 'File is required' });
     const baseUrl =
       process.env.BASE_URL ||
@@ -10,7 +10,14 @@ exports.createItem = async (req, res) => {
         ? `https://${process.env.VERCEL_URL}`
         : `${req.protocol}://${req.get('host')}`);
     const fileUrl = `${baseUrl}/uploads/library/${req.file.filename}`;
-    const item = new LibraryItem({ title, description, fileUrl });
+    const item = new LibraryItem({
+      title,
+      description,
+      category,
+      grade,
+      subject,
+      fileUrl
+    });
     await item.save();
     res.status(201).json({ item });
   } catch (err) {
@@ -48,5 +55,28 @@ exports.deleteItem = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Failed to delete item' });
+  }
+};
+
+exports.updateItem = async (req, res) => {
+  try {
+    const baseUrl =
+      process.env.BASE_URL ||
+      (process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : `${req.protocol}://${req.get('host')}`);
+    const updates = { ...req.body };
+    if (req.file) {
+      updates.fileUrl = `${baseUrl}/uploads/library/${req.file.filename}`;
+    }
+    const item = await LibraryItem.findByIdAndUpdate(req.params.id, updates, {
+      new: true,
+      runValidators: true
+    });
+    if (!item) return res.status(404).json({ message: 'Item not found' });
+    res.json({ item });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to update item' });
   }
 };

--- a/backend/models/LibraryItem.js
+++ b/backend/models/LibraryItem.js
@@ -3,6 +3,13 @@ const mongoose = require('mongoose');
 const libraryItemSchema = new mongoose.Schema({
   title: { type: String, required: true },
   description: String,
+  category: {
+    type: String,
+    enum: ['passpaper', 'book', 'document', 'video', 'other'],
+    required: true
+  },
+  grade: String,
+  subject: String,
   fileUrl: { type: String, required: true },
   createdAt: { type: Date, default: Date.now }
 });

--- a/backend/routes/libraryRoutes.js
+++ b/backend/routes/libraryRoutes.js
@@ -8,5 +8,6 @@ router.post('/library', authenticateToken, requireAdmin, uploadLibrary.single('f
 router.get('/library', controller.getItems);
 router.get('/library/:id', controller.getItemById);
 router.delete('/library/:id', authenticateToken, requireAdmin, controller.deleteItem);
+router.put('/library/:id', authenticateToken, requireAdmin, uploadLibrary.single('file'), controller.updateItem);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,6 +60,7 @@ import PaymentList from './pages/Admin/PaymentList';
 import BankPaymentRequests from './pages/Admin/BankPaymentRequests';
 import LibraryList from './pages/Admin/LibraryList';
 import UploadLibrary from './pages/Admin/UploadLibrary';
+import EditLibrary from './pages/Admin/EditLibrary';
 import InquiryList from './pages/Admin/InquiryList';
 import InquiryDetail from './pages/Admin/InquiryDetail';
 import TeacherListAdmin from './pages/Admin/TeacherList';
@@ -152,6 +153,7 @@ function App() {
         <Route path="/admin/inquiries/:inquiryId" element={<RequireAdmin><InquiryDetail /></RequireAdmin>} />
         <Route path="/admin/library" element={<RequireAdmin><LibraryList /></RequireAdmin>} />
         <Route path="/admin/library/upload" element={<RequireAdmin><UploadLibrary /></RequireAdmin>} />
+        <Route path="/admin/library/:itemId/edit" element={<RequireAdmin><EditLibrary /></RequireAdmin>} />
         <Route path="/admin/teachers" element={<RequireAdmin><TeacherListAdmin /></RequireAdmin>} />
         <Route path="/admin/teachers/create" element={<RequireAdmin><CreateTeacher /></RequireAdmin>} />
         <Route path="/admin/teachers/:teacherId/edit" element={<RequireAdmin><EditTeacher /></RequireAdmin>} />

--- a/frontend/src/pages/Admin/EditLibrary.jsx
+++ b/frontend/src/pages/Admin/EditLibrary.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import api from '../../api';
+
+function EditLibrary() {
+  const { itemId } = useParams();
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    category: 'passpaper',
+    grade: '',
+    subject: ''
+  });
+  const [file, setFile] = useState(null);
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    api
+      .get(`/library/${itemId}`)
+      .then(res => setForm({
+        title: res.data.item.title || '',
+        description: res.data.item.description || '',
+        category: res.data.item.category || 'passpaper',
+        grade: res.data.item.grade || '',
+        subject: res.data.item.subject || ''
+      }))
+      .catch(() => navigate('/admin/library'));
+  }, [itemId, navigate]);
+
+  const handleChange = (e) => {
+    const { name, value, files } = e.target;
+    if (name === 'file' && files) {
+      setFile(files[0]);
+    } else {
+      setForm({ ...form, [name]: value });
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const fd = new FormData();
+      fd.append('title', form.title);
+      fd.append('description', form.description);
+      fd.append('category', form.category);
+      fd.append('grade', form.grade);
+      fd.append('subject', form.subject);
+      if (file) fd.append('file', file);
+      await api.put(`/library/${itemId}`, fd, { headers: { 'Content-Type': 'multipart/form-data' } });
+      setMessage('Item updated');
+      navigate('/admin/library');
+    } catch (err) {
+      setMessage('Update failed');
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h2>Edit Library Item</h2>
+      {message && <div className="alert alert-info">{message}</div>}
+      <form onSubmit={handleSubmit} encType="multipart/form-data">
+        <input
+          className="form-control mb-2"
+          name="title"
+          placeholder="Title"
+          value={form.title}
+          onChange={handleChange}
+          required
+        />
+        <select
+          className="form-control mb-2"
+          name="category"
+          value={form.category}
+          onChange={handleChange}
+          required
+        >
+          <option value="passpaper">Pass Paper</option>
+          <option value="book">Book</option>
+          <option value="document">Document</option>
+          <option value="video">Video</option>
+          <option value="other">Other</option>
+        </select>
+        {form.category === 'passpaper' && (
+          <>
+            <input
+              className="form-control mb-2"
+              name="grade"
+              placeholder="Grade"
+              value={form.grade}
+              onChange={handleChange}
+            />
+            <input
+              className="form-control mb-2"
+              name="subject"
+              placeholder="Subject"
+              value={form.subject}
+              onChange={handleChange}
+            />
+          </>
+        )}
+        <textarea
+          className="form-control mb-2"
+          name="description"
+          placeholder="Description"
+          value={form.description}
+          onChange={handleChange}
+        />
+        <input
+          className="form-control mb-2"
+          name="file"
+          type="file"
+          onChange={handleChange}
+        />
+        <button className="btn btn-primary">Save</button>
+      </form>
+    </div>
+  );
+}
+
+export default EditLibrary;

--- a/frontend/src/pages/Admin/LibraryList.jsx
+++ b/frontend/src/pages/Admin/LibraryList.jsx
@@ -35,6 +35,7 @@ function LibraryList() {
           <li key={it._id} className="list-group-item d-flex justify-content-between">
             <span>{it.title}</span>
             <span>
+              <Link className="btn btn-sm btn-outline-secondary me-2" to={`/admin/library/${it._id}/edit`}>Edit</Link>
               <a className="btn btn-sm btn-outline-primary me-2" href={it.fileUrl} target="_blank" rel="noopener noreferrer">Download</a>
               <button className="btn btn-sm btn-outline-danger" onClick={() => deleteItem(it._id)}>Delete</button>
             </span>

--- a/frontend/src/pages/Admin/UploadLibrary.jsx
+++ b/frontend/src/pages/Admin/UploadLibrary.jsx
@@ -5,6 +5,9 @@ import api from '../../api';
 function UploadLibrary() {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [category, setCategory] = useState('passpaper');
+  const [grade, setGrade] = useState('');
+  const [subject, setSubject] = useState('');
   const [file, setFile] = useState(null);
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
@@ -15,6 +18,9 @@ function UploadLibrary() {
       const fd = new FormData();
       fd.append('title', title);
       fd.append('description', description);
+      fd.append('category', category);
+      fd.append('grade', grade);
+      fd.append('subject', subject);
       if (file) fd.append('file', file);
       await api.post('/library', fd, { headers: { 'Content-Type': 'multipart/form-data' } });
       setMessage('Uploaded');
@@ -36,6 +42,34 @@ function UploadLibrary() {
           onChange={(e) => setTitle(e.target.value)}
           required
         />
+        <select
+          className="form-control mb-2"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          required
+        >
+          <option value="passpaper">Pass Paper</option>
+          <option value="book">Book</option>
+          <option value="document">Document</option>
+          <option value="video">Video</option>
+          <option value="other">Other</option>
+        </select>
+        {category === 'passpaper' && (
+          <>
+            <input
+              className="form-control mb-2"
+              placeholder="Grade"
+              value={grade}
+              onChange={(e) => setGrade(e.target.value)}
+            />
+            <input
+              className="form-control mb-2"
+              placeholder="Subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+            />
+          </>
+        )}
         <textarea
           className="form-control mb-2"
           placeholder="Description"

--- a/frontend/src/pages/ELibrary/ELibrary.jsx
+++ b/frontend/src/pages/ELibrary/ELibrary.jsx
@@ -19,22 +19,26 @@ const ELibrary = () => {
   return (
     <div className="container py-4">
       <h4>E-Library</h4>
-      <ul className="list-group mb-4">
+      <div className="row gy-4 mb-4">
         {items.map((res) => (
-          <li
-            key={res._id}
-            className="list-group-item d-flex justify-content-between"
-          >
-            {res.title}
-            <button
-              className="btn btn-outline-primary btn-sm"
-              onClick={() => openViewer(res)}
-            >
-              View
-            </button>
-          </li>
+          <div key={res._id} className="col-md-4">
+            <div className="card h-100 shadow-sm">
+              <div className="card-body d-flex flex-column">
+                <h5 className="card-title">{res.title}</h5>
+                {res.description && (
+                  <p className="card-text flex-grow-1">{res.description}</p>
+                )}
+                <button
+                  className="btn btn-primary btn-sm mt-auto"
+                  onClick={() => openViewer(res)}
+                >
+                  View
+                </button>
+              </div>
+            </div>
+          </div>
         ))}
-      </ul>
+      </div>
 
       {active && (
         <div className="border p-3 bg-light">


### PR DESCRIPTION
## Summary
- extend `LibraryItem` schema to include category, grade and subject
- update library controller with create and update support
- add update route
- allow admin to input category, grade and subject when uploading
- provide page to edit library items and link from list
- display library items as cards for students

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687741689aa88322aa24e97bb4b6c074